### PR TITLE
Density Plots

### DIFF
--- a/src/octrees.rs
+++ b/src/octrees.rs
@@ -16,7 +16,7 @@ pub struct OctNode {
     points: OutputBuffer,
     /// How many points can fit in this node
     capacity: usize,
-    /// How many fits currently are in this node
+    /// How many points currently are in this node
     count: usize,
     /// Total color. This can be used along with count to compute the average
     /// color
@@ -152,6 +152,42 @@ impl OctNode {
                 depth,
                 max_depth);
         }
+    }
+
+    /// Add a point to this subtree. 
+    ///
+    /// Returns true if the point was added
+    pub fn count_point(
+            &mut self, point: Vec3, color: Vec3, depth: u8) -> bool {
+        
+        // Discard points outside the grid
+        if !self.bounds.contains(&point) {
+            return false;
+        } 
+
+        self.count_point_recursive(point, color, depth);
+        return true;
+    }
+
+    fn count_point_recursive(&mut self, point: Vec3, color: Vec3, depth: u8) {
+        // Update this node's count
+        self.count += 1;
+        self.color_sum = self.color_sum + color;
+
+        // Stop once we hit the desired depth
+        if depth == 0 {
+            return;
+        } 
+
+        // Make sure we can continue down the tree
+        if self.is_leaf() {
+            self.subdivide();
+        }
+
+        // keep propagating down the tree until we reach the desired depth
+        let quadrant = self.bounds.find_quadrant(&point);
+        let child = &mut self.children[quadrant];
+        child.count_point_recursive(point, color, depth - 1);
     }
 
     /// Subdivide a leaf node into an interior node with 8 children, one


### PR DESCRIPTION
This branch will eventually

Things to do

- [ ] Plan when is the best time to compute densities and bounding box centroids
- [ ] Plan what exactly to do with densities. It could be one of the following:
    1. Adjust the point brightness by the density, if density is a number from 0 to 1
    2. use the density to adjust the alpha component. This requires changing both the point cloud writer since the feature table would change format a bit. I'd also have to change `Buffer`'s color type to store more than just Vec3. Probably the most flexible way to do this is to allow Buffer to take an arbitrary type for metadata and pass in structs as I wish.
    3. Store the density separate from color as an extra feature. This might be nice to give me 
- [ ] Generate .pnts files
- [ ] Generate the .tileset.json
- [ ] This time around, implement the idea of writing a utility script to check for files in the viewer directory and generate a fractal_list.json file with their names. Do this in Python because that feels like the easiest thing to do here.
- [ ] Bonus points: add a Name field for the fractal JSON and somehow propagate this so it becomes part of the generated tileset.json's `extras`. Use this in the Python script to give a human-readable label for the dropdown.