### PR TITLE
Add a script to index fractals

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ Where:
 
 Viewer:
 
-* Generate fractals in `viewer/fractal_name`
-* Make sure `viewer/index.html` is updated to list the new fractals
+* Generate fractals in `viewer/<fractal_name>`
+* Run  `python make_index.py` to generate `fractals.json`. This will populate
+  a list of fractals from the tileset JSON files in
+  `viewer/<fractal_name>/tileset.json`. This uses tileset metadata, so only the
+  newer GLB tilesets are supported
 * Run the `viewer` directory as a static site (e.g. via `http-server` (Node.js)
     or `python -m http.server`)

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Where:
 
 Viewer:
 
-* Generate fractals in `viewer/<fractal_name>`
+* Generate fractals in `viewer/<fractal_id>`
 * Run  `python make_index.py` to generate `fractals.json`. This will populate
   a list of fractals from the tileset JSON files in
-  `viewer/<fractal_name>/tileset.json`. This uses tileset metadata, so only the
+  `viewer/<fractal_id>/tileset.json`. This uses tileset metadata, so only the
   newer GLB tilesets are supported
 * Run the `viewer` directory as a static site (e.g. via `http-server` (Node.js)
     or `python -m http.server`)

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Where:
 Viewer:
 
 * Generate fractals in `viewer/<fractal_id>`
-* Run  `python make_index.py` to generate `fractals.json`. This will populate
-  a list of fractals from the tileset JSON files in
-  `viewer/<fractal_id>/tileset.json`. This uses tileset metadata, so only the
-  newer GLB tilesets are supported
+* From the `viewer/` directory, run  `python make_index.py` to generate 
+    `fractals.json`. This is a list of fractal names, IDs and descriptions
+    pulled from the tileset JSON files (`viewer/<fractal_id>/tileset.json`).
+    This only works for newer GLB fractals.
 * Run the `viewer` directory as a static site (e.g. via `http-server` (Node.js)
     or `python -m http.server`)

--- a/logbook.md
+++ b/logbook.md
@@ -132,3 +132,10 @@ I think adding the `3DTILES_metadata` extension will be helpful here.
 The past couple days I wrapped up the 3D Tiles Next stuff and updated most of
 the parameter files to include an id and name. There's a few I didn't get to,
 but I'll handle those later when I go to make a script to index the files.
+
+## 2022-01-24 Automatically populate the UI
+
+This morning I added a script, `viewer/make_index.py` that looks through the
+tileset directories and puts together an index file, `fractals.json`. This
+is now used by the viewer to populate the dropdown. This way, I don't have
+to edit `index.html` every time I add a new fractal.

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -49,27 +49,7 @@
     <div id="cesiumContainer" class="viewer"></div>
     <div id="toolbar">
         <span class="heading">Select Fractal</span>
-        <select id="model">
-            <option value="sierpinski">Sierpinski Tetrahedron</option>
-            <option value="grid_3d">3D Grid</option>
-            <option value="dragon">Dragon Curve Layers</option>
-            <option value="apollonian_gasket">Apollonian Gasket</option>
-            <option value="inv_hyperboloid">Inverse Hyperboloid</option>
-            <option value="spiky_ball">Spiky Ball</option>
-            <option value="spirals_3d">3D Logarithmic Spirals</option>
-            <option value="aa_loxodromic">Axis-Aligned Loxodromic</option>
-            <option value="double_rotation">Double Rotation</option>
-            <option value="many_vertices">Many Vertices Sierpinski</option>
-            <option value="conjugated_sierpinski">Conjugated Sierpinski Tetrahedron</option>
-            <option value="loxodromic">3D Loxodromic Transformation</option>
-
-            <!--
-            <option value="loxodromic2">Perpendicular Loxodromic Transformation</option>
-            <option value="hyperbolic">3D Hyperbolic Transformation</option>
-            <option value="orthogonal_loxodromics">Orthogonal Loxodromic Transformations</option>
-            <option value="sierpinski_tesselation">Sierpinski Tesselation</option>
-            -->
-        </select><br/>
+        <select id="model"></select><br/>
         <span class="heading">Point Cloud Attenuation</span>
         <input id="attenuation" type="checkbox" checked/><br/>
         <span class="heading">Show Bounding Boxes</span>

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -149,7 +149,22 @@ reload_button.addEventListener('click', () => {
     set_model(model_id);
 });
 
-set_model('sierpinski');
+function make_dropdown_option(fractal) {
+    const option = document.createElement("option");
+    option.textContent = fractal.name;
+    option.value = fractal.id;
+    model_select.appendChild(option);
+}
+
+fetch("./fractals.json")
+    .then((response) => response.json())
+    .then((json) => {
+        for (const fractal of json.fractals) {
+            make_dropdown_option(fractal);
+        }
+        model_select.dispatchEvent(new Event("change"));
+    });
+
 configure_camera();
 init_reference_geometry();
 

--- a/viewer/make_index.py
+++ b/viewer/make_index.py
@@ -1,0 +1,49 @@
+import os
+import json
+
+def get_tileset_paths():
+    paths = []
+    with os.scandir() as it:
+        for entry in it:
+            if entry.is_dir():
+                tileset_path = os.path.join(entry.name, "tileset.json")
+                if os.path.exists(tileset_path):
+                    paths.append(tileset_path)
+    return paths
+
+def extract_fractal_info(tileset_json):
+    try:
+        tileset = tileset_json["extensions"]["3DTILES_metadata"]["tileset"]
+        properties = tileset["properties"]
+
+        # We only need the id, name and description for populating the UI
+        return {
+            "id": properties["id"],
+            "name": properties["name"],
+            "description": properties.get("description", "")
+        }
+    except KeyError:
+        return None
+
+def get_fractal_infos(tileset_paths):
+    info = []
+    for tileset_path in tileset_paths:
+        with open(tileset_path, "r") as f:
+            tileset_json = json.load(f)
+            fractal_info = extract_fractal_info(tileset_json)
+            if fractal_info is not None:
+                info.append(fractal_info)
+    return info
+
+
+def main():
+    paths = get_tileset_paths()
+    fractal_info = get_fractal_infos(paths)
+    index_json = {
+        "fractals": fractal_info
+    }
+    with open("fractals.json", "w") as f:
+        json.dump(index_json, f)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a small Python script to gather up the metadata from generated fractals (so long as they show up as `viewer/<fractal_id>/tileset.json`) and make a `fractals.json` file.

The viewer's `main.js` will now do a `fetch()` on this JSON file to populate the dropdown. This way I don't need to manually update it.